### PR TITLE
Use a temporary map for loading the sites list.

### DIFF
--- a/sites.go
+++ b/sites.go
@@ -7,10 +7,11 @@ var (
 )
 
 func SetupSites (config Config) {
-	sites = make(Sites)
+	newsites := make(Sites)
 
 	for hostname, options := range config {
 		debug("Setting up %s", hostname)
-		sites[hostname] = handlersOf(options)
+		newsites[hostname] = handlersOf(options)
 	}
+	sites = newsites
 }


### PR DESCRIPTION
When loading the site list, build the mapping in a temporary variable
and then swap it.  This (I think) fixes a race condition where sites
will not match while the configuration is being updated.

As far as I know, swapping out the map like that is an atomic operation
and this does not require the use of a mutex or making 'sites' not a
global variable and using goroutines to pass around the latest config.
