### PR TITLE
Apply gofmt to project

### DIFF
--- a/auto-reload.go
+++ b/auto-reload.go
@@ -4,7 +4,7 @@ import (
 	"github.com/howeyc/fsnotify"
 )
 
-func AutoReload () {
+func AutoReload() {
 	debug("Enabling")
 
 	watcher, err := fsnotify.NewWatcher()

--- a/boxcars/boxcars.go
+++ b/boxcars/boxcars.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-	"os"
+	"fmt"
 	"github.com/azer/boxcars"
+	"os"
 )
 
 var (
 	filename string
-	port int
+	port     int
 	user_id  int
 	group_id int
-	secure bool
+	secure   bool
 )
 
 func main() {

--- a/config.go
+++ b/config.go
@@ -1,8 +1,8 @@
 package boxcars
 
 import (
-	"io/ioutil"
 	"encoding/json"
+	"io/ioutil"
 )
 
 type Config map[string]map[string]string
@@ -10,7 +10,7 @@ type ConfigRaw map[string]interface{}
 
 var filename string
 
-func ReadConfig () {
+func ReadConfig() {
 	debug("Reading %s", filename)
 
 	configRaw := make(ConfigRaw)
@@ -31,18 +31,18 @@ func ReadConfig () {
 	reloadConfig(configRaw)
 }
 
-func SetFilename (input string) {
+func SetFilename(input string) {
 	debug("Filename set to %s", input)
 	filename = input
 }
 
-func reloadConfig (raw ConfigRaw) {
+func reloadConfig(raw ConfigRaw) {
 	debug("Loading...")
 
 	config := make(Config)
 
 	for hostname, options := range raw {
-		switch t:= options.(type) {
+		switch t := options.(type) {
 		case string:
 			config[hostname] = make(map[string]string)
 			config[hostname]["/"] = t

--- a/debug.go
+++ b/debug.go
@@ -1,7 +1,7 @@
 package boxcars
 
 import (
-	."github.com/azer/debug"
+	. "github.com/azer/debug"
 )
 
 var debug = DebugScope("boxcars", "sites", "server", "auto-reload", "config", "secure")

--- a/handler.go
+++ b/handler.go
@@ -6,7 +6,7 @@ import (
 
 type Handler struct {
 	isReverseProxy bool
-	isStatic bool
-	uri string
-	server http.Handler
+	isStatic       bool
+	uri            string
+	server         http.Handler
 }

--- a/handlers-of.go
+++ b/handlers-of.go
@@ -1,23 +1,23 @@
 package boxcars
 
 import (
-	"regexp"
 	"fmt"
 	"os"
+	"regexp"
 )
 
 type Handlers map[string]*Handler
 
-func handlerOf (uri string, hasCustom404 bool, custom404 string) *Handler {
+func handlerOf(uri string, hasCustom404 bool, custom404 string) *Handler {
 	debug("Setting up the HTTP handler that will serve %s", uri)
 
-	handler := &Handler{ false, false, uri, nil }
+	handler := &Handler{false, false, uri, nil}
 	isStatic := isLocalPath(uri)
 
 	if isStatic && isSingleFile(uri) {
 		handler.isStatic = true
 		handler.server = newSingleFileServer(uri)
-  } else if isStatic {
+	} else if isStatic {
 		handler.isStatic = true
 		handler.server = newStaticServer(uri, hasCustom404, custom404)
 	} else {
@@ -28,7 +28,7 @@ func handlerOf (uri string, hasCustom404 bool, custom404 string) *Handler {
 	return handler
 }
 
-func handlersOf (options map[string]string) Handlers {
+func handlersOf(options map[string]string) Handlers {
 	handlers := make(Handlers)
 
 	custom404, hasCustom404 := options["*"]
@@ -48,12 +48,12 @@ func handlersOf (options map[string]string) Handlers {
 	return handlers
 }
 
-func isLocalPath (config string) bool {
+func isLocalPath(config string) bool {
 	matches, _ := regexp.MatchString("^/", config)
 	return matches
 }
 
-func isSingleFile (uri string) bool {
+func isSingleFile(uri string) bool {
 	f, err := os.Open(uri)
 
 	if err != nil {

--- a/match.go
+++ b/match.go
@@ -1,12 +1,12 @@
 package boxcars
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
-	"fmt"
 )
 
-func matchingHandlerOf (url, hostname string, handlers Handlers) (result http.Handler, found bool) {
+func matchingHandlerOf(url, hostname string, handlers Handlers) (result http.Handler, found bool) {
 
 	if handlers == nil {
 		return nil, false
@@ -35,7 +35,7 @@ func matchingHandlerOf (url, hostname string, handlers Handlers) (result http.Ha
 	return result, found
 }
 
-func matchingServerOf (host, url string) (result http.Handler, found bool) {
+func matchingServerOf(host, url string) (result http.Handler, found bool) {
 
 	hostname := hostnameOf(host)
 	wildcard := wildcardOf(hostname)
@@ -63,7 +63,7 @@ func matchingServerOf (host, url string) (result http.Handler, found bool) {
 	return result, found
 }
 
-func hostnameOf (host string) string {
+func hostnameOf(host string) string {
 	hostname := strings.Split(host, ":")[0]
 
 	if len(hostname) > 4 && hostname[0:4] == "www." {
@@ -73,7 +73,7 @@ func hostnameOf (host string) string {
 	return hostname
 }
 
-func wildcardOf (hostname string) string {
+func wildcardOf(hostname string) string {
 	parts := strings.Split(hostname, ".")
 
 	if len(parts) < 3 {

--- a/secure.go
+++ b/secure.go
@@ -4,7 +4,7 @@ import (
 	"syscall"
 )
 
-func Secure (uid, gid int) {
+func Secure(uid, gid int) {
 	debug("Enabled.")
 
 	if syscall.Getuid() != 0 {
@@ -16,14 +16,14 @@ func Secure (uid, gid int) {
 	debug("Setting GID (group id) to %v", gid)
 	err := syscall.Setgid(gid)
 	if err != nil {
-    debug("Fatal: Failed to set group id: %v", err)
+		debug("Fatal: Failed to set group id: %v", err)
 		debug("  Use -gid parameter to specify the correct group id.")
 	}
 
 	debug("Setting UID (user id) to %v", gid)
 	err = syscall.Setuid(uid)
 	if err != nil {
-    debug("Fatal: Failed to set user id: %v", err)
+		debug("Fatal: Failed to set user id: %v", err)
 		debug("  Use -uid parameter to specify the correct user id.")
 	}
 }

--- a/servers.go
+++ b/servers.go
@@ -1,30 +1,30 @@
 package boxcars
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"regexp"
-	"fmt"
 )
 
-func ReverseProxyServer (uri string) http.Handler {
+func ReverseProxyServer(uri string) http.Handler {
 	debug("Returning a reverse proxy server for %s.", uri)
 	dest, _ := url.Parse(addProtocol(uri))
 	return httputil.NewSingleHostReverseProxy(dest)
 }
 
-func newStaticServer (uri string, hasCustom404 bool, custom404 string) http.Handler {
+func newStaticServer(uri string, hasCustom404 bool, custom404 string) http.Handler {
 	debug("Returning a static server for %s", uri)
-	return &StaticServer{ http.FileServer(http.Dir(uri)), hasCustom404, custom404 }
+	return &StaticServer{http.FileServer(http.Dir(uri)), hasCustom404, custom404}
 }
 
-func newSingleFileServer (uri string) http.Handler {
+func newSingleFileServer(uri string) http.Handler {
 	debug("Returning a single file server for %s", uri)
 	return &SingleFileServer{uri}
 }
 
-func addProtocol (url string) string {
+func addProtocol(url string) string {
 	if matches, _ := regexp.MatchString("^\\w+://", url); !matches {
 		return fmt.Sprintf("http://%s", url)
 	}

--- a/single-file-server.go
+++ b/single-file-server.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 )
 
-type SingleFileServer struct{
+type SingleFileServer struct {
 	uri string
 }
 
-func (server *SingleFileServer) ServeHTTP (w http.ResponseWriter, r *http.Request) {
+func (server *SingleFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, server.uri)
 }

--- a/sites.go
+++ b/sites.go
@@ -6,7 +6,7 @@ var (
 	sites Sites
 )
 
-func SetupSites (config Config) {
+func SetupSites(config Config) {
 	newsites := make(Sites)
 
 	for hostname, options := range config {

--- a/static-server.go
+++ b/static-server.go
@@ -1,17 +1,17 @@
 package boxcars
 
 import (
-	"net/http"
 	"errors"
+	"net/http"
 )
 
 type StaticServer struct {
-	handler http.Handler
+	handler      http.Handler
 	hasCustom404 bool
-	custom404 string
+	custom404    string
 }
 
-func (server *StaticServer) ServeHTTP (writer http.ResponseWriter, request *http.Request) {
+func (server *StaticServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	handler := StaticHandler{}
 	handler.request = request
 	handler.ResponseWriter = writer
@@ -22,11 +22,11 @@ func (server *StaticServer) ServeHTTP (writer http.ResponseWriter, request *http
 type StaticHandler struct {
 	http.ResponseWriter
 	request *http.Request
-	server *StaticServer
-	is404 bool
+	server  *StaticServer
+	is404   bool
 }
 
-func (handler *StaticHandler) WriteHeader (n int) {
+func (handler *StaticHandler) WriteHeader(n int) {
 	if n == http.StatusNotFound && handler.server.hasCustom404 {
 		debug("Serving %s as custom 404.", handler.server.custom404)
 		handler.ResponseWriter.Header().Set("Content-Type", "text/html")
@@ -37,7 +37,7 @@ func (handler *StaticHandler) WriteHeader (n int) {
 	handler.ResponseWriter.WriteHeader(n)
 }
 
-func (handler *StaticHandler) Write (b []byte) (int, error) {
+func (handler *StaticHandler) Write(b []byte) (int, error) {
 	if handler.is404 {
 		return 0, errors.New("404 status written, will serve custom 404 page")
 	}


### PR DESCRIPTION
Many projects and members of the Go community have adopted the `gofmt` tool as the standard way to format Go code.  In order to make contributions to this project more accessible for others can we please apply `gofmt` to the codebase?

I personally have gofmt run on save so when trying to make a contribution to this project I received noise in the diff from the formatting changes.
