### PR TITLE
Fixes issue #7

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -1,3 +1,5 @@
+// +build linux, darwin
+
 package boxcars
 
 import (

--- a/secure_windows.go
+++ b/secure_windows.go
@@ -1,0 +1,5 @@
+package boxcars
+
+func Secure(uid, gid int) {
+  debug("-secure is not applicable to Windows.")
+}


### PR DESCRIPTION
Adds build constraints for `secure.go` to only build on Linux and Mac.
Adds an empty `secure_windows.go` so it can build on Windows.
